### PR TITLE
Fix for problem with IERS workaround

### DIFF
--- a/astroplan/tests/test_utils.py
+++ b/astroplan/tests/test_utils.py
@@ -8,17 +8,23 @@ from astropy.tests.helper import remote_data
 from astropy.utils.data import clear_download_cache
 from astropy.utils import iers
 
-from ..utils import download_IERS_A, IERS_A_in_cache
+from ..utils import (download_IERS_A, IERS_A_in_cache, get_IERS_A_or_workaround,
+                     BACKUP_Time_get_delta_ut1_utc)
 from ..exceptions import OldEarthOrientationDataWarning
 
 @remote_data
 def test_iers_download(monkeypatch, recwarn):
     # the monkeypatch is here to undo the changes that importing astroplan does
     # if the IERS A tables already exist
-    monkeypatch.setattr(iers.IERS_A, 'iers_table', None)
-
     if IERS_A_in_cache():
         clear_download_cache(iers.IERS_A_URL)
+
+    monkeypatch.setattr(iers.IERS, 'iers_table', None)
+    monkeypatch.setattr(iers.IERS_A, 'iers_table', None)
+    monkeypatch.setattr(Time, '_get_delta_ut1_utc', BACKUP_Time_get_delta_ut1_utc)
+
+    # now make sure the state is what it should be given the above changes
+    get_IERS_A_or_workaround()
 
     # first make sure a future time gives a warning with IERS A missing
     nowplusoneyear = Time.now() + 1*u.year

--- a/astroplan/tests/test_utils.py
+++ b/astroplan/tests/test_utils.py
@@ -1,3 +1,31 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+
+from astropy import units as u
+from astropy.time import Time
+from astropy.tests.helper import remote_data
+from astropy.utils.data import clear_download_cache
+from astropy.utils import iers
+
+from ..utils import download_IERS_A, IERS_A_in_cache
+from ..exceptions import OldEarthOrientationDataWarning
+
+@remote_data
+def test_iers_download(monkeypatch, recwarn):
+    # the monkeypatch is here to undo the changes that importing astroplan does
+    # if the IERS A tables already exist
+    monkeypatch.setattr(iers.IERS_A, 'iers_table', None)
+
+    if IERS_A_in_cache():
+        clear_download_cache(iers.IERS_A_URL)
+
+    # first make sure a future time gives a warning with IERS A missing
+    nowplusoneyear = Time.now() + 1*u.year
+    nowplusoneyear.ut1
+    recwarn.pop(OldEarthOrientationDataWarning)
+
+    download_IERS_A()
+
+    #now test that it actually works post-IERS A download:
+    nowplusoneyear.ut1

--- a/astroplan/utils.py
+++ b/astroplan/utils.py
@@ -115,5 +115,5 @@ def download_IERS_A(show_progress=True):
     local_iers_a_path = download_file(iers.IERS_A_URL, cache=True,
                                       show_progress=show_progress)
     # Undo monkey patch set up by get_IERS_A_or_workaround
-    iers.IERS.iers_table = local_iers_a_path
+    iers.IERS.iers_table = iers.IERS_A.open(local_iers_a_path)
     Time._get_delta_ut1_utc = BACKUP_Time_get_delta_ut1_utc


### PR DESCRIPTION
I noticed a problem with the astropy/astroplan#71 approach: `download_IERS_A` wasn't working if you tried to use `Time` in the _same session_.  The underlying problem with how the table is applied at the end of `download_IERS_A`.  This PR fixes that, but more importantly adds a test to catch this.  Of couse it requires downloading, so it uses the `remote_data` decorator.
